### PR TITLE
Make facts Puppet 8 compatible

### DIFF
--- a/lib/facter/couchbase.rb
+++ b/lib/facter/couchbase.rb
@@ -1,6 +1,6 @@
 # Create custom facts if couchbase is found
 
-if FileTest.exists?('/opt/couchbase/VERSION.txt')
+if File.exists?('/opt/couchbase/VERSION.txt')
   Facter.add('couchbase') { setcode { true } }
   fullversion = File.read('/opt/couchbase/VERSION.txt').match /([^-]+)-(.+)/
   Facter.add('couchbase_version') { setcode { fullversion[1] } }


### PR DESCRIPTION
Replaces all occurrences of `FileTest.` with `File.` in the fact ruby files.